### PR TITLE
Force the process exit when creating migrations

### DIFF
--- a/loopback-db-migrate.js
+++ b/loopback-db-migrate.js
@@ -184,6 +184,7 @@ var cmds = {
             fileName = '/' + dateString + (cmdLineName && cmdLineName.indexOf('--') === -1 ? '-' + cmdLineName : '') + '.js';
 
         fs.writeFileSync(dbMigrationsFolder + fileName, fs.readFileSync(__dirname + '/migration-skeleton.js'));
+        process.exit();
     }
 };
 


### PR DESCRIPTION
On my setup I get the following output when creating a migration:

```
$ ./node_modules/loopback-db-migrate/loopback-db-migrate.js create
Using development logs...
{"name":"JobsManager","hostname":"MacBook-Air.local","pid":44027,"level":40,"msg":"Morgan will log everything...","time":"2015-05-21T19:39:57.860Z","v":0}
Enter migration script name:ama
^C # <----------  Had to do Ctrl+C to exit the process and get my prompt back
$
```
