### PR TITLE
Fixed creation of index that does not get populated by LB

### DIFF
--- a/loopback-db-migrate.js
+++ b/loopback-db-migrate.js
@@ -21,10 +21,7 @@ datasource.createModel('Migration', {
         "id": true,
         "type": "String",
         "required": true,
-        "length": 100,
-        "index": {
-            "unique": true
-        }
+        "length": 100
     },
     "db": {
         "type": "String",


### PR DESCRIPTION
We started using `loopback-db-migrate` but ran into the following error after creating our 2nd migration,

```
MongoError: insertDocument :: caused by :: 11000 E11000 duplicate key error index: corpus-dev.Migration.$name_1  dup key: { : null }
```

After some investigation - we discovered that, at least with our version of Loopback, Migration model's `name` property is mapped into `_id`, because it is flagged as an identity field. Because of this, there is no `name` field stored in Mongo for the index to be created against. Thus, the collision on `null` when the 2nd Migration is set for insertion.

We propose that the index simply be removed, as is reflected in this patch. In Mongo, the `_id` field is already uniquely indexed. 

Worth noting - we have not tested on other datastores to see how it behaves.
