### PR TITLE
Allow to provide a different directory parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Down migrations are run in reverse run order.
 Options:
   --datasource specify database name (optional, default: db)
   --since specify date to run migrations from (options, default: run all migrations)
+  --directory specify directory where migration scripts will live (options, default: '/server/migrations/'). A trailing slash is added at the end if not present 
 ```
 
 <h2>Using the CLI directly</h2>
@@ -25,6 +26,11 @@ Run all new migrations that have not previously been run, using datasources.json
 Run all new migrations since 01012014 that have not previously been run, using datasources.json and datasources.qa.json and database 'my_db_name':
 ```javascript
 NODE_ENV=qa ./node_modules/loopback-db-migrate/loopback-db-migrate.js up --datasource my_db_name --since 01012014
+```
+
+Run all migrations living in the '/server/schema-migrations/' directory that have not previously been run, using datasource.json and database 'db'.
+```javascript
+./node_modules/loopback-db-migrate/loopback-db-migrate.js up --directory /server/schema-migrations/
 ```
 
 <h2>Using the CLI with npm by updating your package.json</h2>

--- a/loopback-db-migrate.js
+++ b/loopback-db-migrate.js
@@ -21,10 +21,7 @@ datasource.createModel('Migration', {
         "id": true,
         "type": "String",
         "required": true,
-        "length": 100,
-        "index": {
-            "unique": true
-        }
+        "length": 100
     },
     "db": {
         "type": "String",

--- a/loopback-db-migrate.js
+++ b/loopback-db-migrate.js
@@ -7,7 +7,8 @@ var fs = require('fs'),
     dbName = (dbNameFlag > -1) ? process.argv[dbNameFlag + 1] : 'db',
     dateSinceFlag = process.argv.indexOf('--since'),
     dateSinceFilter = (dateSinceFlag > -1) ? process.argv[dateSinceFlag + 1] : '',
-    migrationsFolder = process.cwd() + '/server/migrations/',
+    migrationsFolderFlag = process.argv.indexOf('--directory'),
+    migrationsFolder = process.cwd() + ( migrationsFolderFlag > -1 ? process.argv[migrationsFolderFlag + 1].replace(/\/?$/, '/') : '/server/migrations/'),
     dbMigrationsFolder = migrationsFolder+dbName,
     datasource = require(process.cwd() + '/server/server.js').dataSources[dbName];
 


### PR DESCRIPTION
Ability to choose which migrations to run on demand.

This comes pretty handy when you want to categorise different types of migrations as you will run them in different steps of your deployment process.

For ie, you may have:
- index addition/deletion
- data migrations
- schema migrations
